### PR TITLE
ENG-3627 :: bump helm v3

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -2,3 +2,9 @@ formatter: "markdown table"
 
 recursive:
   enabled: true
+
+# Root `.terraform.lock.hcl` is gitignored but often exists locally after `terraform
+# init`; without this, terraform-docs resolves exact provider versions from the
+# lockfile while CI (no lockfile) emits constraints — CI pre-commit then fails.
+settings:
+  lockfile: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terraform modules to deploy dbnl in GCP
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.35.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.30 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Terraform modules to deploy dbnl in GCP
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.30 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~>5 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.5 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.35.0 |
 
 ## Modules
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -26,11 +26,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.dbnl.cluster_endpoint}"
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_certificate)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "gke-gcloud-auth-plugin"
       args        = []

--- a/examples/oidc/main.tf
+++ b/examples/oidc/main.tf
@@ -26,11 +26,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = "https://${module.dbnl.cluster_endpoint}"
     cluster_ca_certificate = base64decode(module.dbnl.cluster_ca_certificate)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "gke-gcloud-auth-plugin"
       args        = []

--- a/modules/app/.terraform-docs.yml
+++ b/modules/app/.terraform-docs.yml
@@ -1,7 +1,9 @@
 formatter: "markdown table"
 
-# Matches root repo: local `modules/app/.terraform.lock.hcl` is gitignored; CI has
-# no lockfile — without this, provider column shows resolved helm (e.g. 2.13.2)
-# locally and CI fails.
+# This module’s `.terraform.lock.hcl` is typically gitignored when present; CI has
+# no lockfile. Nested READMEs are generated per-module; without `lockfile: false`
+# here, terraform-docs can still use a local lockfile for provider version cells
+# while CI emits constraints/`n/a` — pre-commit fails. Kept identical across
+# terraform-{aws,azurerm,google}-dbnl.
 settings:
   lockfile: false

--- a/modules/app/.terraform-docs.yml
+++ b/modules/app/.terraform-docs.yml
@@ -1,0 +1,7 @@
+formatter: "markdown table"
+
+# Matches root repo: local `modules/app/.terraform.lock.hcl` is gitignored; CI has
+# no lockfile — without this, provider column shows resolved helm (e.g. 2.13.2)
+# locally and CI fails.
+settings:
+  lockfile: false

--- a/modules/app/README.md
+++ b/modules/app/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.2 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 

--- a/modules/app/README.md
+++ b/modules/app/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 

--- a/modules/app/main.tf
+++ b/modules/app/main.tf
@@ -187,55 +187,22 @@ resource "helm_release" "dbnl" {
 
   values = [yamlencode(local.values)]
 
-  dynamic "set_sensitive" {
-    # for_each needs a list, but it's essentially a "count = ? 1 : 0"
-    for_each = local.admin_enabled ? ["admin-enabled"] : []
-    content {
-      name  = "auth.admin.hashedPassword"
-      value = bcrypt(var.admin_password)
-    }
-  }
-
-  set_sensitive {
-    name  = "auth.devToken.privateKey"
-    value = var.dev_token_private_key
-  }
-
-  set_sensitive {
-    name  = "redis.username"
-    value = var.redis_username
-  }
-
-  set_sensitive {
-    name  = "redis.password"
-    value = var.redis_password
-  }
-
-  set_sensitive {
-    name  = "db.username"
-    value = var.db_username
-  }
-
-  set_sensitive {
-    name  = "db.password"
-    value = var.db_password
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-password"] : []
-    content {
-      name  = "flower.basicAuth.password"
-      value = var.flower_basic_auth_password
-    }
-  }
-
-  dynamic "set_sensitive" {
-    for_each = local.flower_basic_auth_enabled ? ["flower-basic-auth-username"] : []
-    content {
-      name  = "flower.basicAuth.username"
-      value = var.flower_basic_auth_username
-    }
-  }
+  set_sensitive = concat(
+    [
+      { name = "auth.devToken.privateKey", value = var.dev_token_private_key },
+      { name = "redis.username", value = var.redis_username },
+      { name = "redis.password", value = var.redis_password },
+      { name = "db.username", value = var.db_username },
+      { name = "db.password", value = var.db_password },
+    ],
+    local.admin_enabled ? [
+      { name = "auth.admin.hashedPassword", value = bcrypt(var.admin_password) },
+    ] : [],
+    local.flower_basic_auth_enabled ? [
+      { name = "flower.basicAuth.password", value = var.flower_basic_auth_password },
+      { name = "flower.basicAuth.username", value = var.flower_basic_auth_username },
+    ] : [],
+  )
 
   lifecycle {
     precondition {

--- a/providers.tf
+++ b/providers.tf
@@ -18,7 +18,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.5"
+      version = "~> 3.0"
     }
   }
 


### PR DESCRIPTION
## 📌 Summary

- Bump `hashicorp/helm` constraint from `~> 2.5` to `~> 3.0` (installed v3.1.1).
- Migrate provider config to v3 syntax: nested `kubernetes {}` / `exec {}` blocks → attribute assignment (`kubernetes = {}`, `exec = {}`) in both examples.
- Migrate `helm_release` in `modules/app` to v3 syntax: repeated `set_sensitive {}` + `dynamic "set_sensitive"` blocks → a single `set_sensitive` list attribute built with `concat(...)`.
- Validated locally with `terraform validate` in both `examples/basic` and `examples/oidc` (no cloud API calls / plan run).

Related PRs:
- aws: https://github.com/dbnlAI/terraform-aws-dbnl/pull/13
- azurerm: https://github.com/dbnlAI/terraform-azurerm-dbnl/pull/8

Made with [Cursor](https://cursor.com)